### PR TITLE
Rename identity method to id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ var Component = require('choo/component')
 var html = require('choo/html')
 
 module.exports = class Article extends Component {
-  static identity (article) {
+  static id (article) {
     return `article-${article.id}`
   }
 
@@ -48,7 +48,7 @@ cache(myComponent)
 Create a new Nanocache instance.
 
 ### `cache.render(Nanocomponent)`
-Render a Nanocomponent instance. It checks a static `identity` method that
+Render a Nanocomponent instance. It checks a static `id` method that
 returns an id. If the id is not registered in the cache, it creates a new
 instance and caches it. If the id already exists, it returns the cached
 instance.

--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ ChooComponentCache.prototype.render = function (Component) {
     args.push(arguments[i])
   }
 
-  assert.equal(typeof Component.identity, 'function', 'ChooComponentCache.render: Component.identity should be type function')
-  var id = Component.identity(args)
-  assert.equal(typeof id, 'string', 'ChooComponentCache.render: Component.identity should return type string')
+  assert.equal(typeof Component.id, 'function', 'ChooComponentCache.render: Component.id should be type function')
+  var id = Component.id.apply(Component, args)
+  assert.equal(typeof id, 'string', 'ChooComponentCache.render: Component.id should return type string')
 
   var el = this.cache[id]
   if (!el) {


### PR DESCRIPTION
As per discussions change the name of the static `identity` method to just `id` in hopes of achieving parity with nanocomponent internal `id` prop and element `id` attribute.